### PR TITLE
Use env vars for Paynow credentials

### DIFF
--- a/.github/workflows/main_chindegebackend.yml
+++ b/.github/workflows/main_chindegebackend.yml
@@ -78,4 +78,9 @@ jobs:
         with:
           app-name: 'ChindegeBackend'
           slot-name: 'Production'
+        env:
+          PAYNOW_ID: ${{ secrets.PAYNOW_ID }}
+          PAYNOW_KEY: ${{ secrets.PAYNOW_KEY }}
+          PAYNOW_RETURN_URL: ${{ secrets.PAYNOW_RETURN_URL }}
+          PAYNOW_RESULT_URL: ${{ secrets.PAYNOW_RESULT_URL }}
           

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Chindege Backend
+
+This project requires several environment variables for interacting with the Paynow service:
+
+- `PAYNOW_ID` – Paynow integration ID
+- `PAYNOW_KEY` – Paynow integration key
+- `PAYNOW_RETURN_URL` – URL users are redirected to after payment
+- `PAYNOW_RESULT_URL` – URL that receives Paynow payment status notifications
+
+Set these variables in your deployment environment so that `game/services/payment_service.py` can access them at runtime.

--- a/game/services/payment_service.py
+++ b/game/services/payment_service.py
@@ -2,12 +2,13 @@ from paynow import Paynow
 from game.models import User, Transaction
 import requests
 from urllib.parse import parse_qs
+import os
 
-# Credentials (should be environment variables in production)
-PAYNOW_INTEGRATION_ID = "20952"
-PAYNOW_INTEGRATION_KEY = "7899c1ff-5656-4c37-af85-ed6b0f462bbb"
-PAYNOW_RETURN_URL = "https://unity3d.com"
-PAYNOW_RESULT_URL = "https://webhook.site/a5888fc0-fe03-4f42-80f7-ffdadca13f5d"
+# Credentials now pulled from environment variables
+PAYNOW_INTEGRATION_ID = os.getenv("PAYNOW_ID")
+PAYNOW_INTEGRATION_KEY = os.getenv("PAYNOW_KEY")
+PAYNOW_RETURN_URL = os.getenv("PAYNOW_RETURN_URL")
+PAYNOW_RESULT_URL = os.getenv("PAYNOW_RESULT_URL")
 
 paynow = Paynow(
     PAYNOW_INTEGRATION_ID,


### PR DESCRIPTION
## Summary
- read Paynow credentials and URLs from environment variables
- document required environment variables in README
- supply Paynow secrets to GitHub Actions deploy job

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SECRET_KEY=foo python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6846071ff94483259a52a3488232947f