### PR TITLE
Add unit tests for engine, tasks and payment

### DIFF
--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,0 +1,13 @@
+from chindege_backend.settings import *
+
+SECRET_KEY = 'test-key'
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+CHANNEL_LAYERS = {
+    "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
+}
+

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,8 @@
+import pytest
+from game.engine import generate_crash_point
+
+
+def test_generate_crash_point_deterministic():
+    result = generate_crash_point('server', 'client')
+    assert result == 1.72
+    assert result >= 1.01

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from unittest.mock import Mock, patch
+
+from game.services.payment_service import create_payment, check_payment_status
+from game.models import Transaction
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class PaymentServiceTests(TestCase):
+    @patch('game.services.payment_service.paynow')
+    def test_create_payment_success(self, mock_paynow):
+        payment_obj = Mock()
+        payment_obj.reference = 'ref123'
+        payment_obj.add = Mock()
+        mock_paynow.create_payment.return_value = payment_obj
+        mock_response = Mock(success=True, redirect_url='http://pay', poll_url='http://poll')
+        mock_paynow.send.return_value = mock_response
+
+        result = create_payment('test@example.com', 10)
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['redirect_url'], 'http://pay')
+        self.assertEqual(Transaction.objects.count(), 1)
+
+    @patch('requests.get')
+    def test_check_payment_status(self, mock_get):
+        mock_get.return_value = Mock(status_code=200, text='status=Paid&reference=test%40example.com&amount=10&paynowreference=xyz')
+        result = check_payment_status('http://poll')
+        self.assertEqual(result['status'], 'Paid')
+        self.assertEqual(result['email'], 'test@example.com')
+        self.assertEqual(result['amount'], '10')
+        self.assertEqual(result['paynow_reference'], 'xyz')
+

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from unittest.mock import patch
+
+from game.models import GameRound
+from game.tasks import start_new_round
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class StartNewRoundTests(TestCase):
+    @patch('game.tasks.generate_crash_point')
+    def test_start_new_round_creates_record(self, mock_gen):
+        mock_gen.return_value = 1.23
+        round_obj = start_new_round()
+        self.assertIsInstance(round_obj, GameRound)
+        self.assertEqual(round_obj.crash_point, 1.23)
+        self.assertTrue(GameRound.objects.filter(id=round_obj.id).exists())
+


### PR DESCRIPTION
## Summary
- create `tests` package with SQLite test settings
- test `generate_crash_point`
- test `start_new_round` with mocked crash point
- test payment service logic with mocked Paynow and requests

## Testing
- `DJANGO_SETTINGS_MODULE=tests.settings_test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684607d4dabc8325a2e2f9e908ac1a75