### PR TITLE
Add basic auth and game endpoints

### DIFF
--- a/chindege_backend/views.py
+++ b/chindege_backend/views.py
@@ -1,6 +1,15 @@
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from django.contrib.auth import authenticate
+from rest_framework_simplejwt.tokens import RefreshToken
 from game.services.payment_service import create_payment, check_payment_status
+from game.serializers import UserSerializer, GameRoundSerializer
+from game.tasks import start_new_round
+from game.models import Bet, GameRound
+from django.utils.timezone import now
 import logging
 
 logger = logging.getLogger(__name__)
@@ -25,7 +34,7 @@ def initiate_payment(request):
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
 
-def paynow_status(request):
+def check_payment_status(request):
     # ✅ FIX: Extract poll_url cleanly as a string before doing anything else
     poll_url = request.GET.get("poll_url", "").strip()
 
@@ -48,26 +57,83 @@ def paynow_webhook(request):
     return JsonResponse({"status": "received"})
 
 @csrf_exempt
+@api_view(['POST'])
+@permission_classes([AllowAny])
 def register_user(request):
-    return JsonResponse({"message": "User registered ✅"}, status=200)
+    serializer = UserSerializer(data=request.data)
+    if serializer.is_valid():
+        user = serializer.save()
+        refresh = RefreshToken.for_user(user)
+        return Response({
+            "id": user.id,
+            "username": user.username,
+            "access": str(refresh.access_token),
+            "refresh": str(refresh)
+        })
+    return Response(serializer.errors, status=400)
 
 @csrf_exempt
+@api_view(['POST'])
+@permission_classes([AllowAny])
 def login_user(request):
-    return JsonResponse({"message": "Login successful ✅"}, status=200)
+    username = request.data.get("username")
+    password = request.data.get("password")
+    user = authenticate(request, username=username, password=password)
+    if user:
+        refresh = RefreshToken.for_user(user)
+        return Response({
+            "access": str(refresh.access_token),
+            "refresh": str(refresh)
+        })
+    return Response({"detail": "Invalid credentials"}, status=400)
 
 @csrf_exempt
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def get_user_profile(request):
-    return JsonResponse({"user": "sample_user"}, status=200)
+    serializer = UserSerializer(request.user)
+    return Response(serializer.data)
 
 @csrf_exempt
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def start_game(request):
-    return JsonResponse({"message": "Game started"}, status=200)
+    round_obj = start_new_round()
+    serializer = GameRoundSerializer(round_obj)
+    return Response(serializer.data)
 
 @csrf_exempt
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def submit_score(request):
-    return JsonResponse({"message": "Score submitted"}, status=200)
+    round_id = request.data.get('round_id')
+    amount = request.data.get('amount')
+    cash_out_multiplier = request.data.get('cash_out_multiplier')
+    try:
+        round_obj = GameRound.objects.get(id=round_id)
+    except GameRound.DoesNotExist:
+        return Response({'detail': 'Round not found'}, status=404)
+    bet = Bet.objects.create(
+        user_id=request.user.id,
+        round=round_obj,
+        amount=amount,
+        cash_out_multiplier=cash_out_multiplier,
+        cashed_out_at=now()
+    )
+    return Response({'id': bet.id})
 
 @csrf_exempt
+@api_view(['GET'])
+@permission_classes([AllowAny])
 def get_leaderboard(request):
-    return JsonResponse({"leaderboard": []}, status=200)
+    bets = Bet.objects.exclude(cash_out_multiplier__isnull=True).order_by('-cash_out_multiplier')[:10]
+    data = [
+        {
+            'user_id': b.user_id,
+            'multiplier': b.cash_out_multiplier,
+            'amount': str(b.amount)
+        }
+        for b in bets
+    ]
+    return Response({'leaderboard': data})
 

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,0 +1,13 @@
+from chindege_backend.settings import *
+
+SECRET_KEY = 'test-key'
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+CHANNEL_LAYERS = {
+    "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
+}
+

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,8 @@
+import pytest
+from game.engine import generate_crash_point
+
+
+def test_generate_crash_point_deterministic():
+    result = generate_crash_point('server', 'client')
+    assert result == 1.72
+    assert result >= 1.01

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from unittest.mock import Mock, patch
+
+from game.services.payment_service import create_payment, check_payment_status
+from game.models import Transaction
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class PaymentServiceTests(TestCase):
+    @patch('game.services.payment_service.paynow')
+    def test_create_payment_success(self, mock_paynow):
+        payment_obj = Mock()
+        payment_obj.reference = 'ref123'
+        payment_obj.add = Mock()
+        mock_paynow.create_payment.return_value = payment_obj
+        mock_response = Mock(success=True, redirect_url='http://pay', poll_url='http://poll')
+        mock_paynow.send.return_value = mock_response
+
+        result = create_payment('test@example.com', 10)
+
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['redirect_url'], 'http://pay')
+        self.assertEqual(Transaction.objects.count(), 1)
+
+    @patch('requests.get')
+    def test_check_payment_status(self, mock_get):
+        mock_get.return_value = Mock(status_code=200, text='status=Paid&reference=test%40example.com&amount=10&paynowreference=xyz')
+        result = check_payment_status('http://poll')
+        self.assertEqual(result['status'], 'Paid')
+        self.assertEqual(result['email'], 'test@example.com')
+        self.assertEqual(result['amount'], '10')
+        self.assertEqual(result['paynow_reference'], 'xyz')
+

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from unittest.mock import patch
+
+from game.models import GameRound
+from game.tasks import start_new_round
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class StartNewRoundTests(TestCase):
+    @patch('game.tasks.generate_crash_point')
+    def test_start_new_round_creates_record(self, mock_gen):
+        mock_gen.return_value = 1.23
+        round_obj = start_new_round()
+        self.assertIsInstance(round_obj, GameRound)
+        self.assertEqual(round_obj.crash_point, 1.23)
+        self.assertTrue(GameRound.objects.filter(id=round_obj.id).exists())
+


### PR DESCRIPTION
## Summary
- implement registration, login, profile, leaderboard and score submission
- start new rounds when starting a game
- use JWT tokens for authentication

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=tests.settings_test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684607d4dabc8325a2e2f9e908ac1a75